### PR TITLE
Update crashs.md

### DIFF
--- a/guides/crashs/crashs.md
+++ b/guides/crashs/crashs.md
@@ -14,5 +14,5 @@ stepbystep: true
 ![Logfenster](/guides/crashs/log.jpg)
 - **Schritt 4:** Kopiere den Link aus dem geöffneten Browserfenster
 ![Browserfenster](/guides/crashs/browser.jpg)
-- **Schritt 5:** Wende dich mit dem Crashreport an ein Teammitglied (z.B. über Teamspeak oder Forum)
+- **Schritt 5:** Wende dich mit dem Crashreport an ein Teammitglied (z.B. über Teamspeak, Forum oder auch via Discord Support Channel bzw. Ticketsystem)
 ![Kontakt](/guides/crashs/kontakt.jpg)


### PR DESCRIPTION
Da Spieler immer wieder fragen ob sie den Link zum Crashreport in den #support Channel auf dem Discord Server schicken dürfen oder diesen direkt einem Teammitglied per Discord PM schicken (was ja laut Discord Regeln nicht gemacht werden sollte) sollte es nun etwas klarer sein was mit dem Link zu tun ist.