### PR TITLE
Hinzufügen von weiterer Support Funktion

### DIFF
--- a/guides/kein_mod_online/kein_mod_online.md
+++ b/guides/kein_mod_online/kein_mod_online.md
@@ -12,7 +12,7 @@ Sollte es dazu kommen, dass ein Server fast leer ist und sich kein Moderator auf
 Ingame kannst du mit dem Befehl `/report <Spieler> <Grund>` einen Spieler melden, falls dieser einen Regelverstoß begangen hat.
 Beweise in Form von Screenshots sind dabei hilfreich.
 
-Des Weiteren kannst du auch mit `/support <Frage>` deine Supportanfrage stellen, dadurch werden Teammitglieder benachrichtigt und können dir schnell bei deinem Problem helfen.
+Des Weiteren kannst du auch mit `/support <Frage>` deine Supportanfrage stellen. Dadurch werden Teammitglieder benachrichtigt und können dir schnell bei deinem Problem helfen.
 
 ---
 

--- a/guides/kein_mod_online/kein_mod_online.md
+++ b/guides/kein_mod_online/kein_mod_online.md
@@ -12,6 +12,8 @@ Sollte es dazu kommen, dass ein Server fast leer ist und sich kein Moderator auf
 Ingame kannst du mit dem Befehl `/report <Spieler> <Grund>` einen Spieler melden, falls dieser einen Regelverstoß begangen hat.
 Beweise in Form von Screenshots sind dabei hilfreich.
 
+Weiters kannst du auch mit `/support <Frage>` deine Supportanfrage stellen, dadurch werden Teammitglieder benachrichtigt und können dir schnell bei deinen Problem helfen.
+
 ---
 
 Sehr viele Moderatoren befinden sich trotz Abwesenheit auf dem [MyFTB TeamSpeak Server](https://myftb.de/teamspeak). Dort kannst du dich in dem `Support & Hilfe` Channel deines Modpacks melden. Handelt es sich zum Beispiel um ein technisches Problem mit dem MyFTB Launcher, dann solltest du mit Hilfe [dieser Anleitung](/crashs) die Log des Launchers hochladen und diese im `Technik Support` Channel ganz oben im TeamSpeak einem Teammitglied schicken.

--- a/guides/kein_mod_online/kein_mod_online.md
+++ b/guides/kein_mod_online/kein_mod_online.md
@@ -12,7 +12,7 @@ Sollte es dazu kommen, dass ein Server fast leer ist und sich kein Moderator auf
 Ingame kannst du mit dem Befehl `/report <Spieler> <Grund>` einen Spieler melden, falls dieser einen Regelverstoß begangen hat.
 Beweise in Form von Screenshots sind dabei hilfreich.
 
-Weiters kannst du auch mit `/support <Frage>` deine Supportanfrage stellen, dadurch werden Teammitglieder benachrichtigt und können dir schnell bei deinen Problem helfen.
+Des Weiteren kannst du auch mit `/support <Frage>` deine Supportanfrage stellen, dadurch werden Teammitglieder benachrichtigt und können dir schnell bei deinem Problem helfen.
 
 ---
 

--- a/guides/weltenverwaltung/weltenverwaltung.md
+++ b/guides/weltenverwaltung/weltenverwaltung.md
@@ -52,4 +52,3 @@ Weitere nützliche Befehle für die Weltenverwaltung:
 - `/settpworld` - Setzt den Spawnpunkt deiner Welt um
 - `/unlock` bzw. `/lock` - Erlaubt bzw. sperrt den Zutritt von Nicht-Mitbewohnern zu deiner Welt
 - `/pvp` - Aktiviert bzw. deaktiviert PvP in deiner Welt
-  

--- a/guides/weltenverwaltung/weltenverwaltung.md
+++ b/guides/weltenverwaltung/weltenverwaltung.md
@@ -52,3 +52,4 @@ Weitere nützliche Befehle für die Weltenverwaltung:
 - `/settpworld` - Setzt den Spawnpunkt deiner Welt um
 - `/unlock` bzw. `/lock` - Erlaubt bzw. sperrt den Zutritt von Nicht-Mitbewohnern zu deiner Welt
 - `/pvp` - Aktiviert bzw. deaktiviert PvP in deiner Welt
+  


### PR DESCRIPTION
Beim Artikel "Was tun, wenn kein Moderator online ist?", hat noch der /support Befehl gefehlt bei den ingame Befehlen.